### PR TITLE
Add settings to change workday hours

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,7 +96,7 @@ checksum = "22813a6dc45b335f9bade10bf7271dc477e81113e89eb251a0bc2a8a81c536e1"
 dependencies = [
  "bstr",
  "csv-core",
- "itoa",
+ "itoa 0.4.8",
  "ryu",
  "serde",
 ]
@@ -119,6 +119,7 @@ dependencies = [
  "csv",
  "lazy_static",
  "serde",
+ "serde_json",
  "time",
  "tui",
 ]
@@ -137,6 +138,12 @@ name = "itoa"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
+
+[[package]]
+name = "itoa"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112c678d4050afce233f4f2852bb2eb519230b3cf12f33585275537d7e41578d"
 
 [[package]]
 name = "lazy_static"
@@ -311,6 +318,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_json"
+version = "1.0.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b7ce2b32a1aed03c558dc61a5cd328f15aff2dbc17daad8fb8af04d2100e15c"
+dependencies = [
+ "itoa 1.0.2",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "signal-hook"
 version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -386,7 +404,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41effe7cfa8af36f439fac33861b66b049edc6f9a32331e2312660529c1c24ad"
 dependencies = [
- "itoa",
+ "itoa 0.4.8",
  "libc",
  "serde",
  "time-macros",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,17 +111,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
+]
+
+[[package]]
 name = "effort"
 version = "0.1.0"
 dependencies = [
  "anyhow",
  "crossterm 0.22.1",
  "csv",
+ "dirs",
  "lazy_static",
  "serde",
  "serde_json",
  "time",
  "tui",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
@@ -153,9 +185,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.108"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8521a1b57e76b1ec69af7599e75e38e7b7fad6610f037db8c79b127201b5d119"
+checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
 
 [[package]]
 name = "lock_api"
@@ -263,9 +295,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.10"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
+checksum = "62f25bc4c7e55e0b0b7a1d43fb893f4fa1361d0abe38b9ce4f323c2adfe6ef42"
 dependencies = [
  "bitflags",
 ]
@@ -277,6 +309,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8440d8acb4fd3d277125b4bd01a6f38aee8d814b3b5fc09b3f2b825d37d3fe8f"
 dependencies = [
  "redox_syscall",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
+dependencies = [
+ "getrandom",
+ "redox_syscall",
+ "thiserror",
 ]
 
 [[package]]
@@ -399,6 +442,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror"
+version = "1.0.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd829fe32373d27f76265620b5309d0340cb8550f523c1dda251d6298069069a"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0396bc89e626244658bef819e22d0cc459e795a5ebe878e6ec336d1674a8d79a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "time"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -447,6 +510,12 @@ name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,4 @@ serde = { version = "1.0.130", features = ["derive"] }
 time = { version = "0.3.5", features = ["local-offset", "formatting", "serde", "macros", "parsing", "serde-human-readable"] }
 tui = { version = "0.15", features = ["crossterm"] }
 serde_json = "1.0.81"
+dirs = "4.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,4 @@ lazy_static = "1.4.0"
 serde = { version = "1.0.130", features = ["derive"] }
 time = { version = "0.3.5", features = ["local-offset", "formatting", "serde", "macros", "parsing", "serde-human-readable"] }
 tui = { version = "0.15", features = ["crossterm"] }
+serde_json = "1.0.81"

--- a/src/app.rs
+++ b/src/app.rs
@@ -60,7 +60,7 @@ impl App {
 
     pub fn new(filename: String, activities: Vec<Activity>, days_off: Vec<Date>) -> Self {
         let mut conf_path = dirs::config_dir().unwrap();
-        conf_path.push("effort_config");
+        conf_path.push("effortrc");
         let config = load_config(conf_path.clone()).unwrap_or_default();
         Self {
             filename,

--- a/src/app/config.rs
+++ b/src/app/config.rs
@@ -1,0 +1,167 @@
+use std::{
+    any::Any,
+    fs::File,
+    io::{self, BufReader, BufWriter, Write},
+    path::Path,
+};
+
+use crate::app::App;
+use crate::traits::EditingPopUp;
+use serde::{Deserialize, Serialize};
+
+use tui::{
+    style::{Color, Style},
+    widgets::{Block, Borders, Paragraph},
+};
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, PartialOrd, Copy)]
+pub struct Config {
+    pub work_day_hours: f32,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Config {
+            work_day_hours: 8.0,
+        }
+    }
+}
+
+pub fn load_config<P: AsRef<Path>>(path: P) -> io::Result<Config> {
+    match File::open(format!("{}-config", path.as_ref().display())) {
+        Ok(f) => {
+            let file = BufReader::new(f);
+            Ok(serde_json::from_reader(file).unwrap_or_default())
+        }
+        Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(Config::default()),
+        Err(e) => Err(e),
+    }
+}
+
+pub fn store_config<W>(writer: W, config: Config) -> io::Result<()>
+where
+    W: Write,
+{
+    let file = BufWriter::new(writer);
+    serde_json::to_writer_pretty(file, &config)?;
+    Ok(())
+}
+
+#[derive(Debug, Clone)]
+pub struct ConfigBeingBuilt {
+    pub work_day_hours: String,
+    pub selected: ConfigSelected,
+    pub editing: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ConfigSelected {
+    WorkDayHours,
+}
+
+impl ConfigSelected {
+    pub fn next(self) -> Self {
+        match self {
+            Self::WorkDayHours => Self::WorkDayHours,
+        }
+    }
+
+    pub fn prev(self) -> Self {
+        match self {
+            Self::WorkDayHours => Self::WorkDayHours,
+        }
+    }
+}
+
+impl ConfigBeingBuilt {
+    pub fn new(config: Config) -> Self {
+        Self {
+            work_day_hours: config.work_day_hours.to_string(),
+            selected: ConfigSelected::WorkDayHours,
+            editing: true,
+        }
+    }
+}
+
+impl EditingPopUp for ConfigBeingBuilt {
+    fn select_next(&mut self) {
+        self.selected = self.selected.next();
+    }
+
+    fn select_prev(&mut self) {
+        self.selected = self.selected.prev();
+    }
+
+    fn selected_buf(&mut self) -> &mut String {
+        match self.selected {
+            ConfigSelected::WorkDayHours => &mut self.work_day_hours,
+        }
+    }
+
+    fn set_editing(&mut self, state: bool) {
+        self.editing = state;
+    }
+
+    fn is_editing(&self) -> bool {
+        self.editing
+    }
+
+    fn submit(&self, app: &mut App) -> Result<(), &'static str> {
+        app.config = self.try_into()?;
+        app.pop_up = None;
+        let _ = app.save_to(&app.filename);
+        Ok(())
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn render(&self) -> Vec<tui::widgets::Paragraph<'_>> {
+        let mkparagraph = |title, buf, action| {
+            Paragraph::new(buf)
+                .style(if action == self.selected {
+                    let color = if self.editing {
+                        Color::Yellow
+                    } else {
+                        Color::Blue
+                    };
+                    Style::default().fg(color)
+                } else {
+                    Style::default()
+                })
+                .block(Block::default().borders(Borders::ALL).title(title))
+        };
+        vec![mkparagraph(
+            "workday hours",
+            self.work_day_hours.to_string(),
+            ConfigSelected::WorkDayHours,
+        )]
+    }
+
+    fn popup_type(&self) -> crate::app::PopUpType {
+        crate::app::PopUpType::Config
+    }
+}
+
+impl TryFrom<&ConfigBeingBuilt> for Config {
+    type Error = &'static str;
+
+    fn try_from(builder: &ConfigBeingBuilt) -> Result<Self, Self::Error> {
+        let work_day_hours = builder.work_day_hours.parse::<f32>();
+        match work_day_hours {
+            Ok(wdh) => Ok(Config {
+                work_day_hours: wdh,
+            }),
+            Err(_) => Err("Please Provide a number"),
+        }
+    }
+}
+
+impl TryFrom<&mut ConfigBeingBuilt> for Config {
+    type Error = &'static str;
+
+    fn try_from(builder: &mut ConfigBeingBuilt) -> Result<Self, Self::Error> {
+        Config::try_from(&*builder)
+    }
+}

--- a/src/app/config.rs
+++ b/src/app/config.rs
@@ -150,9 +150,15 @@ impl TryFrom<&ConfigBeingBuilt> for Config {
     fn try_from(builder: &ConfigBeingBuilt) -> Result<Self, Self::Error> {
         let work_day_hours = builder.work_day_hours.parse::<f32>();
         match work_day_hours {
-            Ok(wdh) => Ok(Config {
-                work_day_hours: wdh,
-            }),
+            Ok(wdh) => {
+                if wdh < 0.0 {
+                    Err("Work Hours need to be a positive number")
+                } else {
+                    Ok(Config {
+                        work_day_hours: wdh,
+                    })
+                }
+            }
             Err(_) => Err("Please Provide a number"),
         }
     }

--- a/src/app/config.rs
+++ b/src/app/config.rs
@@ -28,7 +28,7 @@ impl Default for Config {
 }
 
 pub fn load_config<P: AsRef<Path>>(path: P) -> io::Result<Config> {
-    match File::open(format!("{}-config", path.as_ref().display())) {
+    match File::open(path) {
         Ok(f) => {
             let file = BufReader::new(f);
             Ok(serde_json::from_reader(file).unwrap_or_default())

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 mod app;
 mod combo_buffer;
 mod selected_vec;
+mod traits;
 mod ui;
 mod util;
 
@@ -84,9 +85,9 @@ fn run_app<B: Backend>(terminal: &mut Terminal<B>, app: &mut App) -> anyhow::Res
             }
             let n_days_off = app.n_days_off();
             match app.pop_up_mut() {
-                Some(PopUp::EditingActivity(new)) => {
+                Some(PopUp::EditingPopUp(new)) => {
                     combo_buffer.reset();
-                    if new.editing {
+                    if new.is_editing() {
                         match key.code {
                             KeyCode::Char(c) => new.selected_buf().push(c),
                             KeyCode::Backspace => {
@@ -94,9 +95,9 @@ fn run_app<B: Backend>(terminal: &mut Terminal<B>, app: &mut App) -> anyhow::Res
                             }
                             KeyCode::Tab => new.select_next(),
                             KeyCode::BackTab => new.select_prev(),
-                            KeyCode::Esc => new.editing = false,
+                            KeyCode::Esc => new.set_editing(false),
                             KeyCode::Enter => {
-                                if let Err(msg) = app.submit_activity() {
+                                if let Err(msg) = app.submit() {
                                     info_popup = Some(Err(msg.into()))
                                 }
                             }
@@ -104,12 +105,12 @@ fn run_app<B: Backend>(terminal: &mut Terminal<B>, app: &mut App) -> anyhow::Res
                         }
                     } else {
                         match key.code {
-                            KeyCode::Char('i') => new.editing = true,
+                            KeyCode::Char('i') => new.set_editing(true),
                             KeyCode::Char('k') => new.select_prev(),
                             KeyCode::Char('j') => new.select_next(),
                             KeyCode::Esc => app.cancel_edit(),
                             KeyCode::Enter => {
-                                if let Err(msg) = app.submit_activity() {
+                                if let Err(msg) = app.submit() {
                                     info_popup = Some(Err(msg.into()))
                                 }
                             }
@@ -150,6 +151,7 @@ fn run_app<B: Backend>(terminal: &mut Terminal<B>, app: &mut App) -> anyhow::Res
                         KeyCode::Char('j') => app.next(),
                         KeyCode::Char('s') => app.toggle_stats(),
                         KeyCode::Char('o') => app.create_new_activity(),
+                        KeyCode::Char('?') => app.edit_config(),
                         KeyCode::Char('u') => app.undo(),
                         KeyCode::Char('r') if key.modifiers == KeyModifiers::CONTROL => app.redo(),
                         KeyCode::Char('e') => app.edit_activity(),

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,0 +1,14 @@
+use crate::App;
+use std::any::Any;
+
+pub trait EditingPopUp {
+    fn set_editing(&mut self, state: bool);
+    fn is_editing(&self) -> bool;
+    fn select_next(&mut self);
+    fn select_prev(&mut self);
+    fn selected_buf(&mut self) -> &mut String;
+    fn submit(&self, app: &mut App) -> Result<(), &'static str>;
+    fn render(&self) -> Vec<tui::widgets::Paragraph<'_>>;
+    fn popup_type(&self) -> crate::app::PopUpType;
+    fn as_any(&self) -> &dyn Any;
+}

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -14,7 +14,7 @@ use tui::{
 };
 
 use crate::{
-    app::{Activity, ActivityBeingBuilt, App, PopUp, Selected},
+    app::{Activity, App, PopUp},
     selected_vec::SelectedVec,
     traits::EditingPopUp,
     util::{


### PR DESCRIPTION
Added settings screen, can be accessed by pressing '?'.
This menu was made by reusing the 'Edit Action' popup.
It takes values like '8.6'.

Settings are saved on '<base-file-name>-config', in json format.
